### PR TITLE
Bind kmp method

### DIFF
--- a/kmp-matcher.js
+++ b/kmp-matcher.js
@@ -3,7 +3,7 @@
         kmp: function(s, p) {
             var n = s.length;
             var m = p.length;
-            var prefix = this.calcPrefixFunction(p);
+            var prefix = kmp_matcher.calcPrefixFunction(p);
             var res = [];
             var q = -1;
             for(var i = 0; i < n; i++) {


### PR DESCRIPTION
Current state of affairs makes it impossible to just do

```js
var kmp = require('kmp-matcher').kmp;

// use kmp
```

because of context-awareness of this function which in this case is hardly a useful feature.

This patch binds `kmp` function so that one can use it without a context.